### PR TITLE
Correct the name of the 'exp' claim

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -115,7 +115,7 @@ func generateToken(k *SigningKeyPair, issuer string, cfg TokenConfig, custom *Cu
 		"sub": "jwt-this",
 		"iss": issuer,
 		"iat": jwt.NewNumericDate(time.Now()),
-		"eat": jwt.NewNumericDate(time.Now().Add(cfg.Validity)),
+		"exp": jwt.NewNumericDate(time.Now().Add(cfg.Validity)),
 	}
 	if cfg.Audience != "" {
 		claims["aud"] = cfg.Audience


### PR DESCRIPTION
I ran into issues when trying to use jwt-this with a server that validates JWT tokens using Microsoft's `JwtSecurityTokenHandler` with the `RequireExpirationTime` property set to true.

https://learn.microsoft.com/en-us/previous-versions/visualstudio/dn464137(v=vs.114)

I see that `exp` is listed in the `claimsSupported` list and `eat` was not, but the expiration time was being included when generating a JWT as the `eat` claim. As far as I can tell `eat` is not actually an intended claim name, unless I am missing something. Renaming the claim when generating the JWT resolves the validation issue for me.